### PR TITLE
fix(simulated-data)

### DIFF
--- a/gdcdictionary/schemas/publication_file.yaml
+++ b/gdcdictionary/schemas/publication_file.yaml
@@ -58,7 +58,6 @@ properties:
   data_type:
     term:
       $ref: "_terms.yaml#/data_type"
-    type: string
     enum:
       - Journal Article
       - White Paper


### PR DESCRIPTION
The data simulator uses the `type` field to decide which type of data to simulate when `type` is specified; in this case it should not be specified since it's an enum (https://github.com/uc-cdis/data-simulator/blob/master/datasimulator/node.py#L226 is used instead of https://github.com/uc-cdis/data-simulator/blob/master/datasimulator/node.py#L253)

So when submitting, we get the error `'22c4932fa0' is not one of ['Journal Article', 'White Paper', 'Bulletin', 'Map', 'Fact Sheet']`